### PR TITLE
[cgo] Fixes #41 Declare function SKY_base58_String2Hex 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Added functions `SKY_base58_String2Hex`
 ### Fixed
-
 - `/api/v1/health` will return correct build info when running Docker containers based on `skycoin/skycoin` mainnet image.
 
 ### Changed

--- a/lib/cgo/cipher.base58.base58.go
+++ b/lib/cgo/cipher.base58.base58.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/hex"
 	"reflect"
 	"unsafe"
 
@@ -16,6 +17,17 @@ import (
 */
 import "C"
 
+//export SKY_base58_String2Hex
+func SKY_base58_String2Hex(_s string, _arg1 *C.GoSlice_) (____error_code uint32) {
+	s := _s
+	__arg1, ____return_err := hex.DecodeString(s)
+	____error_code = libErrorCode(____return_err)
+	if ____return_err == nil {
+		copyToGoSlice(reflect.ValueOf(__arg1), _arg1)
+	}
+
+	return
+}
 //export SKY_base58_Hex2Base58
 func SKY_base58_Hex2Base58(_val []byte, _arg1 *C.GoString_) (____error_code uint32) {
 	val := *(*[]byte)(unsafe.Pointer(&_val))


### PR DESCRIPTION
Fixes #41 

Changes:
- Declare `function SKY_base58_String2Hex` in `cipher.base58.base58.go`

Does this change need to mentioned in CHANGELOG.md?
yes

Requires testing
yes

Comments about testing , should you have some
This function is only used in the libraries exported by it, it is not necessary in libskycoin, but in the other libraries inherited from it