### PR TITLE
fixes #18 - Fix Travis deploy prior to 0.25.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ deploy:
     draft: true
     overwrite: true
     on:
-      repo: skycoin/hardware-wallet
+      repo: skycoin/libskycoin
       tags: true
 notifications:
   email: false


### PR DESCRIPTION
Fixes #18

Changes:
- Correct repository constraint for Travis deployment

Does this change need to mentioned in CHANGELOG.md?
no

Requires testing
no
