### PR TITLE
Build curl lib in release mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Be able to set a build type for lib curl.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Be able to set a build type for lib curl.
 
 ### Added
 
@@ -19,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Be able to set a build type for lib curl.
 - Export functions in Skycoin 0.25.1 core API's
 - `skyapi` C client for Skycoin node REST at `lib/curl`.
 - Support for building `libskycoin` on ARM and 32 / 64 bits.

--- a/lib/curl/CMakeLists.txt
+++ b/lib/curl/CMakeLists.txt
@@ -6,7 +6,9 @@ project(CGenerator)
 #set(CMAKE_C_VISIBILITY_PRESET default)
 #set(CMAKE_CXX_VISIBILITY_PRESET default)
 #set(CMAKE_VISIBILITY_INLINES_HIDDEN OFF)
-set(CMAKE_BUILD_TYPE Debug)
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Debug)
+endif(NOT CMAKE_BUILD_TYPE)
 
 set(pkgName "skyapi")
 
@@ -79,6 +81,8 @@ add_library(${pkgName} SHARED ${SRCS} ${HDRS})
 target_link_libraries(${pkgName} ${CURL_LIBRARIES})
 #install library to destination
 install(TARGETS ${pkgName} DESTINATION ${CMAKE_INSTALL_PREFIX})
+
+unset(CMAKE_BUILD_TYPE CACHE)
 
 # Setting file variables to null
 #set(SRCS "")

--- a/lib/curl/install_lib_curl.sh
+++ b/lib/curl/install_lib_curl.sh
@@ -7,7 +7,7 @@ cd build
 #echo "brew ls --verbose curl"
 #brew ls --verbose curl
 # for normal install use following command
-cmake -DCMAKE_VERBOSE_MAKEFILE=ON ..
+cmake -DCMAKE_BUILD_TYPE=Release ..
 grep -R object_convertToJSON ../../
 make
 sudo make install


### PR DESCRIPTION
Fixes #66

Changes:
- Be able to set a build type for lib curl.
- Shut your mouth make...

Does this change need to mentioned in CHANGELOG.md?
yes

Requires testing
no
