### PR TITLE
Fixes #79 Including certain missing skycoin cipher lib test vectors

### DIFF
--- a/include/json.h
+++ b/include/json.h
@@ -166,7 +166,7 @@ typedef struct _json_value {
 #endif
 
 
-    /* Some C++ operator sugar */
+/* Some C++ operator sugar */
 
 #ifdef __cplusplus
 

--- a/lib/cgo/cipher.base58.base58.go
+++ b/lib/cgo/cipher.base58.base58.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/hex"
 	"reflect"
 	"unsafe"
 
@@ -36,6 +37,18 @@ func SKY_base58_Encode(_bin []byte, _arg1 *C.GoString_) (____error_code uint32) 
 func SKY_base58_Decode(_s string, _arg1 *C.GoSlice_) (____error_code uint32) {
 	s := _s
 	__arg1, ____return_err := base58.Decode(s)
+	____error_code = libErrorCode(____return_err)
+	if ____return_err == nil {
+		copyToGoSlice(reflect.ValueOf(__arg1), _arg1)
+	}
+
+	return
+}
+
+//export SKY_base58_String2Hex
+func SKY_base58_String2Hex(_s string, _arg1 *C.GoSlice_) (____error_code uint32) {
+	s := _s
+	__arg1, ____return_err := hex.DecodeString(s)
 	____error_code = libErrorCode(____return_err)
 	if ____return_err == nil {
 		copyToGoSlice(reflect.ValueOf(__arg1), _arg1)

--- a/lib/cgo/cipher.secp256k1-go.secp256k1.go
+++ b/lib/cgo/cipher.secp256k1-go.secp256k1.go
@@ -39,3 +39,15 @@ func SKY_secp256k1_VerifySecKey(__seckey []byte) (____error_code int) {
 	____error_code = secp256k1.VerifySeckey(seckey)
 	return
 }
+
+//export SKY_secp256k1_ECDH
+func SKY_secp256k1_ECDH(_pub []byte, _sec []byte, _arg1 *C.GoSlice_) (____error_code uint32) {
+	pubkey := *(*[]byte)(unsafe.Pointer(&_pub))
+	seckey := *(*[]byte)(unsafe.Pointer(&_sec))
+	__arg1 := secp256k1.ECDH(pubkey, seckey)
+	if __arg1 != nil {
+		copyToGoSlice(reflect.ValueOf(__arg1), _arg1)
+		return SKY_OK
+	}
+	return SKY_ERROR
+}

--- a/lib/cgo/cipher.secp256k1-go.secp256k1.go
+++ b/lib/cgo/cipher.secp256k1-go.secp256k1.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"reflect"
+	"unsafe"
+
+	"github.com/skycoin/skycoin/src/cipher/secp256k1-go"
+)
+
+/*
+
+#include <string.h>
+#include <stdlib.h>
+#include "skytypes.h"
+*/
+import "C"
+
+//export SKY_secp256k1_PubkeyFromSeckey
+func SKY_secp256k1_PubkeyFromSeckey(__seckey []byte, _arg1 *C.GoSlice_) (____error_code uint32) {
+	seckey := *(*[]byte)(unsafe.Pointer(&__seckey))
+	__arg1 := secp256k1.PubkeyFromSeckey(seckey)
+	if __arg1 != nil {
+		copyToGoSlice(reflect.ValueOf(__arg1), _arg1)
+		return SKY_OK
+	}
+	return SKY_ERROR
+}
+
+//export SKY_secp256k1_VerifyPubkey
+func SKY_secp256k1_VerifyPubkey(__pubkey []byte) (____error_code int) {
+	pubkey := *(*[]byte)(unsafe.Pointer(&__pubkey))
+	____error_code = secp256k1.VerifyPubkey(pubkey)
+	return
+}
+
+//export SKY_secp256k1_VerifySecKey
+func SKY_secp256k1_VerifySecKey(__seckey []byte) (____error_code int) {
+	seckey := *(*[]byte)(unsafe.Pointer(&__seckey))
+	____error_code = secp256k1.VerifySeckey(seckey)
+	return
+}

--- a/lib/cgo/tests/check_cipher.address.c
+++ b/lib/cgo/tests/check_cipher.address.c
@@ -306,13 +306,13 @@ Suite* cipher_address(void)
 
     tc = tcase_create("cipher.address");
     tcase_add_checked_fixture(tc, setup, teardown);
-    // tcase_add_test(tc, TestDecodeBase58Address);
-    // tcase_add_test(tc, TestAddressFromBytes);
-    // tcase_add_test(tc, TestAddressRoundtrip);
-    // tcase_add_test(tc, TestAddressVerify);
-    // tcase_add_test(tc, TestAddressString);
-    // tcase_add_test(tc, TestAddressBulk);
-    // tcase_add_test(tc, TestAddressNull);
+    tcase_add_test(tc, TestDecodeBase58Address);
+    tcase_add_test(tc, TestAddressFromBytes);
+    tcase_add_test(tc, TestAddressRoundtrip);
+    tcase_add_test(tc, TestAddressVerify);
+    tcase_add_test(tc, TestAddressString);
+    tcase_add_test(tc, TestAddressBulk);
+    tcase_add_test(tc, TestAddressNull);
     suite_add_tcase(s, tc);
     tcase_set_timeout(tc, 150);
 

--- a/lib/cgo/tests/check_cipher.crypto.c
+++ b/lib/cgo/tests/check_cipher.crypto.c
@@ -593,7 +593,7 @@ START_TEST(TestVerifyAddressSignedHash)
     ck_assert(errorcode == SKY_OK);
     errorcode = SKY_cipher_VerifyAddressSignedHash(&addr2, &sig2, &h);
     ck_assert(errorcode == SKY_OK);
-    ck_assert(!isU8Eq(sig, sig2, 65));
+    ck_assert_int_eq(isU8Eq(sig, sig2, 65), 0);
 
     randBytes(&b, 256);
     SKY_cipher_SumSHA256(b, &h);
@@ -603,7 +603,7 @@ START_TEST(TestVerifyAddressSignedHash)
     ck_assert(errorcode == SKY_OK);
     errorcode = SKY_cipher_VerifyAddressSignedHash(&addr2, &sig2, &h);
     ck_assert(errorcode == SKY_OK);
-    ck_assert(!isU8Eq(sig, sig2, 65));
+    ck_assert_int_eq(isU8Eq(sig, sig2, 65), 0);
 
     // Bad address should be invalid
     errorcode = SKY_cipher_VerifyAddressSignedHash(&addr, &sig2, &h);
@@ -632,7 +632,7 @@ START_TEST(TestSignHash)
     errorcode = SKY_cipher_SignHash(&h, &sk, &sig);
     ck_assert(errorcode == SKY_OK);
     memset((void*)&sig2, 0, 65);
-    ck_assert(!isU8Eq(sig, sig2, 65));
+    ck_assert_int_eq(isU8Eq(sig, sig2, 65), 0);
     errorcode = SKY_cipher_VerifyAddressSignedHash(&addr, &sig, &h);
     ck_assert(errorcode == SKY_OK);
 

--- a/lib/cgo/tests/check_cipher.hash.c
+++ b/lib/cgo/tests/check_cipher.hash.c
@@ -32,13 +32,13 @@ START_TEST(TestHashRipemd160)
     SKY_cipher_HashRipemd160(slice, &tmp);
     randBytes(&slice, 160);
     SKY_cipher_HashRipemd160(slice, &r);
-    ck_assert(!isU8Eq(tmp, r, sizeof(cipher__Ripemd160)));
+    ck_assert_int_eq(isU8Eq(tmp, r, sizeof(cipher__Ripemd160)), 0);
 
     unsigned char buff1[257];
     GoSlice b = {buff1, 0, 257};
     randBytes(&b, 256);
     SKY_cipher_HashRipemd160(b, &r2);
-    ck_assert(!isU8Eq(tmp, r2, sizeof(cipher__Ripemd160)));
+    ck_assert_int_eq(isU8Eq(tmp, r2, sizeof(cipher__Ripemd160)), 0);
     freshSumRipemd160(b, &tmp);
     ck_assert(isU8Eq(tmp, r2, sizeof(cipher__Ripemd160)));
 }
@@ -186,12 +186,12 @@ START_TEST(TestSumSHA256)
     randBytes(&b, 256);
     SKY_cipher_SumSHA256(b, &h1);
     cipher__SHA256 tmp;
-    ck_assert(!isU8Eq(h1, tmp, 32));
+    ck_assert_int_eq(isU8Eq(h1, tmp, 32), 0);
     GoSlice c = {cbuff, 0, 257};
     randBytes(&c, 256);
     cipher__SHA256 h2;
     SKY_cipher_SumSHA256(c, &h2);
-    ck_assert(!isU8Eq(h1, tmp, 32));
+    ck_assert_int_eq(isU8Eq(h1, tmp, 32), 0);
     cipher__SHA256 tmp_h2;
     freshSumSHA256(c, &tmp_h2);
     ck_assert(isU8Eq(h2, tmp_h2, 32));
@@ -239,9 +239,9 @@ START_TEST(TestDoubleSHA256)
     cipher__SHA256 h;
     cipher__SHA256 tmp;
     SKY_cipher_DoubleSHA256(b, &h);
-    ck_assert(!isU8Eq(tmp, h, 32));
+    ck_assert_int_eq(isU8Eq(tmp, h, 32), 0);
     freshSumSHA256(b, &tmp);
-    ck_assert(!isU8Eq(tmp, h, 32));
+    ck_assert_int_eq(isU8Eq(tmp, h, 32), 0);
 }
 END_TEST
 
@@ -263,9 +263,9 @@ START_TEST(TestAddSHA256)
     cipher__SHA256 tmp;
 
     SKY_cipher_AddSHA256(&h, &i, &add);
-    ck_assert(!isU8Eq(add, tmp, 32));
-    ck_assert(!isU8Eq(add, h, 32));
-    ck_assert(!isU8Eq(add, i, 32));
+    ck_assert_int_eq(isU8Eq(add, tmp, 32), 0);
+    ck_assert_int_eq(isU8Eq(add, h, 32), 0);
+    ck_assert_int_eq(isU8Eq(add, i, 32), 0);
 }
 END_TEST
 
@@ -287,9 +287,9 @@ START_TEST(TestXorSHA256)
 
     SKY_cipher_SHA256_Xor(&h, &i, &tmp_xor1);
     SKY_cipher_SHA256_Xor(&i, &h, &tmp_xor2);
-    ck_assert(!isU8Eq(tmp_xor1, h, 32));
-    ck_assert(!isU8Eq(tmp_xor1, i, 32));
-    ck_assert(!isU8Eq(tmp_xor1, tmp, 32));
+    ck_assert_int_eq(isU8Eq(tmp_xor1, h, 32), 0);
+    ck_assert_int_eq(isU8Eq(tmp_xor1, i, 32), 0);
+    ck_assert_int_eq(isU8Eq(tmp_xor1, tmp, 32), 0);
     ck_assert(isU8Eq(tmp_xor1, tmp_xor2, 32));
 }
 END_TEST

--- a/lib/cgo/tests/check_cipher.hash.c
+++ b/lib/cgo/tests/check_cipher.hash.c
@@ -180,12 +180,13 @@ END_TEST
 
 START_TEST(TestSumSHA256)
 {
-    unsigned char bbuff[257], cbuff[257];
+    GoUint8 bbuff[257];
+    GoUint8 cbuff[257];
     GoSlice b = {bbuff, 0, 257};
     cipher__SHA256 h1;
     randBytes(&b, 256);
     SKY_cipher_SumSHA256(b, &h1);
-    cipher__SHA256 tmp;
+    cipher__SHA256 tmp = "";
     ck_assert_int_eq(isU8Eq(h1, tmp, 32), 0);
     GoSlice c = {cbuff, 0, 257};
     randBytes(&c, 256);

--- a/lib/cgo/tests/check_cipher.secp256k1.c
+++ b/lib/cgo/tests/check_cipher.secp256k1.c
@@ -7,13 +7,72 @@
 #include "skytest.h"
 #include <check.h>
 
+GoString _testSeckey[] = {
+    {"08efb79385c9a8b0d1c6f5f6511be0c6f6c2902963d874a3a4bacc18802528d3", 64},
+    {"78298d9ecdc0640c9ae6883201a53f4518055442642024d23c45858f45d0c3e6", 64},
+    {"04e04fe65bfa6ded50a12769a3bd83d7351b2dbff08c9bac14662b23a3294b9e", 64},
+    {"2f5141f1b75747996c5de77c911dae062d16ae48799052c04ead20ccd5afa113", 64},
+};
+
 START_TEST(Test_Abnormal_Keys2)
 {
-   ck_assert_double_eq(0,0);
+    for (size_t i = 0; i < 4; i++) {
+        GoUint8_ buffer_seckey[1024];
+        coin__UxArray seckey1 = {buffer_seckey, 0, 1024};
+        GoUint32_ err;
+        err = SKY_base58_String2Hex(_testSeckey[i], &seckey1);
+        ck_assert_msg(err == SKY_OK, "Fail in iteration %d, err %x != %x", i, err, SKY_OK);
+        GoUint8_ buffer_pubkey[1024];
+        GoSlice seckey_slice = {seckey1.data, seckey1.len, seckey1.cap};
+        coin__UxArray pubkey1 = {buffer_pubkey, 0, 1024};
+        err = SKY_secp256k1_PubkeyFromSeckey(seckey_slice, &pubkey1);
+        ck_assert_msg(err == SKY_OK, "Fail in iteration %d, err %x != %x", i, err, SKY_OK);
+        GoSlice pubkey_slice = {pubkey1.data, pubkey1.len, pubkey1.cap};
+        err = SKY_secp256k1_VerifyPubkey(pubkey_slice);
+        ck_assert_msg(err == 1, "generates key that fails validation in ite #%d", i);
+    }
 }
 END_TEST
 
-Suite* cipher_secp256k1(void)
+START_TEST(Test_Abnormal_Keys3)
+{
+    for (size_t i = 0; i < 4; i++) {
+        GoUint8_ buffer_seckey[1024];
+        coin__UxArray seckey1 = {buffer_seckey, 0, 1024};
+        GoUint32 err;
+        err = SKY_base58_String2Hex(_testSeckey[i], &seckey1);
+        ck_assert_msg(err == SKY_OK, "Fail in iteration %d, err %x != %x", i, err, SKY_OK);
+        GoUint8_ buffer_pubkey[1024];
+        GoSlice seckey_slice = {seckey1.data, seckey1.len, seckey1.cap};
+        coin__UxArray pubkey1 = {buffer_pubkey, 0, 1024};
+        err = SKY_secp256k1_PubkeyFromSeckey(seckey_slice, &pubkey1);
+        ck_assert_msg(err == SKY_OK, "Fail in iteration %d, err %x != %x", i, err, SKY_OK);
+        GoSlice pubkey1_slice = {pubkey1.data, pubkey1.len, pubkey1.cap};
+        GoInt n = rand() % 4;
+
+        GoUint8_ buffer_seckey2[1024];
+        coin__UxArray seckey2 = {buffer_seckey, 0, 1024};
+        err = SKY_base58_String2Hex(_testSeckey[n], &seckey2);
+        ck_assert_msg(err == SKY_OK, "Fail in iteration %d, err %x != %x", i, err, SKY_OK);
+        GoUint8_ buffer_pubkey2[1024];
+        GoSlice seckey2_slice = {seckey2.data, seckey2.len, seckey2.cap};
+        coin__UxArray pubkey2 = {buffer_pubkey2, 0, 1024};
+        err = SKY_secp256k1_PubkeyFromSeckey(seckey2_slice, &pubkey2);
+        ck_assert_msg(err == SKY_OK, "Fail in iteration %d, err %x != %x", i, err, SKY_OK);
+        GoSlice pubkey2_slice = {pubkey2.data, pubkey2.len, pubkey2.cap};
+        GoUint8 buffer_puba[1024];
+        coin__UxArray puba = {buffer_puba, 0, 1024};
+        GoUint8 buffer_pubb[1024];
+        coin__UxArray pubb = {buffer_pubb, 0, 1024};
+        err = SKY_secp256k1_ECDH(pubkey1_slice, seckey2_slice, &puba);
+        ck_assert_msg(err == SKY_OK, "Fail in iteration %d, err %x != %x", i, err, SKY_OK);
+        err = SKY_secp256k1_ECDH(pubkey2_slice, seckey_slice, &pubb);
+        ck_assert_msg(err == SKY_OK, "Fail in iteration %d, err %x != %x", i, err, SKY_OK);
+    }
+}
+END_TEST
+Suite*
+cipher_secp256k1(void)
 {
     Suite* s = suite_create("Load cipher.secp256k1");
     TCase* tc;
@@ -21,6 +80,7 @@ Suite* cipher_secp256k1(void)
     tc = tcase_create("cipher.secp256k1");
     tcase_add_checked_fixture(tc, setup, teardown);
     tcase_add_test(tc, Test_Abnormal_Keys2);
+    tcase_add_test(tc, Test_Abnormal_Keys3);
     suite_add_tcase(s, tc);
     tcase_set_timeout(tc, 150);
 

--- a/lib/cgo/tests/check_cipher.secp256k1.c
+++ b/lib/cgo/tests/check_cipher.secp256k1.c
@@ -9,7 +9,7 @@
 
 START_TEST(Test_Abnormal_Keys2)
 {
-   
+   ck_assert_double_eq(0,0);
 }
 END_TEST
 

--- a/lib/cgo/tests/check_cipher.secp256k1.c
+++ b/lib/cgo/tests/check_cipher.secp256k1.c
@@ -1,0 +1,28 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "libskycoin.h"
+#include "skyerrors.h"
+#include "skystring.h"
+#include "skytest.h"
+#include <check.h>
+
+START_TEST(Test_Abnormal_Keys2)
+{
+   
+}
+END_TEST
+
+Suite* cipher_secp256k1(void)
+{
+    Suite* s = suite_create("Load cipher.secp256k1");
+    TCase* tc;
+
+    tc = tcase_create("cipher.secp256k1");
+    tcase_add_checked_fixture(tc, setup, teardown);
+    tcase_add_test(tc, Test_Abnormal_Keys2);
+    suite_add_tcase(s, tc);
+    tcase_set_timeout(tc, 150);
+
+    return s;
+}

--- a/lib/cgo/tests/check_coin.block.c
+++ b/lib/cgo/tests/check_coin.block.c
@@ -152,7 +152,7 @@ START_TEST(TestBlockHashHeader)
     ck_assert_msg(result == SKY_OK, "SKY_coin_BlockHeader_Hash failed");
     ck_assert(isU8Eq(hash1, hash2, sizeof(cipher__SHA256)));
     strcpy(hash2, "");
-    ck_assert(!isU8Eq(hash1, hash2, sizeof(cipher__SHA256)));
+    ck_assert_int_eq(isU8Eq(hash1, hash2, sizeof(cipher__SHA256)), 0);
 }
 END_TEST
 

--- a/lib/cgo/tests/check_coin.outputs.c
+++ b/lib/cgo/tests/check_coin.outputs.c
@@ -25,7 +25,7 @@ START_TEST(TestUxBodyHash)
     result = SKY_coin_UxBody_Hash(&uxbody, &hash);
     ck_assert_msg(result == SKY_OK, "SKY_coin_UxBody_Hash failed");
     cipher__SHA256 nullHash = "";
-    ck_assert(!isU8Eq(nullHash, hash, sizeof(cipher__SHA256)));
+    ck_assert_int_eq(isU8Eq(nullHash, hash, sizeof(cipher__SHA256)), 0);
 }
 END_TEST
 
@@ -69,37 +69,37 @@ START_TEST(TestUxOutSnapshotHash)
     memcpy(&uxout2, &uxout, sizeof(coin__UxOut));
     uxout2.Head.Time = 20;
     result = SKY_coin_UxOut_SnapshotHash(&uxout2, &hash2);
-    ck_assert_msg(!isU8Eq(hash1, hash2, sizeof(cipher__SHA256)), "SKY_coin_UxOut_SnapshotHash failed");
+    ck_assert_int_eq(isU8Eq(hash1, hash2, sizeof(cipher__SHA256)), 0);
 
     memcpy(&uxout2, &uxout, sizeof(coin__UxOut));
     uxout2.Head.BkSeq = 4;
     result = SKY_coin_UxOut_SnapshotHash(&uxout2, &hash2);
     ck_assert_msg(result == SKY_OK, "SKY_coin_UxOut_SnapshotHash failed");
-    ck_assert_msg((!isU8Eq(hash1, hash2, sizeof(cipher__SHA256))), "Snapshot hash must be different");
+    ck_assert_int_eq((isU8Eq(hash1, hash2, sizeof(cipher__SHA256))), 0);
 
     memcpy(&uxout2, &uxout, sizeof(coin__UxOut));
     makeRandHash(&uxout2.Body.SrcTransaction);
     result = SKY_coin_UxOut_SnapshotHash(&uxout2, &hash2);
     ck_assert_msg(result == SKY_OK, "SKY_coin_UxOut_SnapshotHash failed");
-    ck_assert_msg((!isU8Eq(hash1, hash2, sizeof(cipher__SHA256))), "Snapshot hash must be different");
+    ck_assert_int_eq((isU8Eq(hash1, hash2, sizeof(cipher__SHA256))), 0);
 
     memcpy(&uxout2, &uxout, sizeof(coin__UxOut));
     makeAddress(&uxout2.Body.Address);
     result = SKY_coin_UxOut_SnapshotHash(&uxout2, &hash2);
     ck_assert_msg(result == SKY_OK, "SKY_coin_UxOut_SnapshotHash failed");
-    ck_assert_msg((!isU8Eq(hash1, hash2, sizeof(cipher__SHA256))), "Snapshot hash must be different");
+    ck_assert_msg((isU8Eq(hash1, hash2, sizeof(cipher__SHA256))) == 0, "Snapshot hash must be different");
 
     memcpy(&uxout2, &uxout, sizeof(coin__UxOut));
     uxout2.Body.Coins = uxout.Body.Coins * 2;
     result = SKY_coin_UxOut_SnapshotHash(&uxout2, &hash2);
     ck_assert_msg(result == SKY_OK, "SKY_coin_UxOut_SnapshotHash failed");
-    ck_assert_msg((!isU8Eq(hash1, hash2, sizeof(cipher__SHA256))), "Snapshot hash must be different");
+    ck_assert_msg((isU8Eq(hash1, hash2, sizeof(cipher__SHA256))) == 0, "Snapshot hash must be different");
 
     memcpy(&uxout2, &uxout, sizeof(coin__UxOut));
     uxout2.Body.Hours = uxout.Body.Hours * 2;
     result = SKY_coin_UxOut_SnapshotHash(&uxout2, &hash2);
     ck_assert_msg(result == SKY_OK, "SKY_coin_UxOut_SnapshotHash failed");
-    ck_assert_msg((!isU8Eq(hash1, hash2, sizeof(cipher__SHA256))), "Snapshot hash must be different");
+    ck_assert_msg((isU8Eq(hash1, hash2, sizeof(cipher__SHA256))) == 0, "Snapshot hash must be different");
 }
 END_TEST
 

--- a/lib/cgo/tests/check_coin.transactions.c
+++ b/lib/cgo/tests/check_coin.transactions.c
@@ -260,10 +260,10 @@ START_TEST(TestTransactionHash)
     memset(&nullHash, 0, sizeof(cipher__SHA256));
     result = SKY_coin_Transaction_Hash(handle, &hash1);
     ck_assert(result == SKY_OK);
-    ck_assert(!isU8Eq(nullHash, hash1, sizeof(cipher__SHA256)));
+    ck_assert_int_eq(isU8Eq(nullHash, hash1, sizeof(cipher__SHA256)), 0);
     result = SKY_coin_Transaction_HashInner(handle, &hash2);
     ck_assert(result == SKY_OK);
-    ck_assert(!isU8Eq(hash2, hash1, sizeof(cipher__SHA256)));
+    ck_assert_int_eq(isU8Eq(hash2, hash1, sizeof(cipher__SHA256)), 0);
 }
 END_TEST
 
@@ -280,7 +280,7 @@ START_TEST(TestTransactionUpdateHeader)
     memcpy(&hash, &ptx->InnerHash, sizeof(cipher__SHA256));
     memset(&ptx->InnerHash, 0, sizeof(cipher__SHA256));
     result = SKY_coin_Transaction_UpdateHeader(handle);
-    ck_assert(!isU8Eq(ptx->InnerHash, nullHash, sizeof(cipher__SHA256)));
+    ck_assert_int_eq(isU8Eq(ptx->InnerHash, nullHash, sizeof(cipher__SHA256)), 0);
     ck_assert(isU8Eq(ptx->InnerHash, hash, sizeof(cipher__SHA256)));
     result = SKY_coin_Transaction_HashInner(handle, &hashInner);
     ck_assert(result == SKY_OK);
@@ -530,7 +530,7 @@ START_TEST(TestTransactionHashInner)
     cipher__SHA256 hash, nullHash = "";
     result = SKY_coin_Transaction_HashInner(handle1, &hash);
     ck_assert(result == SKY_OK);
-    ck_assert(!isU8Eq(nullHash, hash, sizeof(cipher__SHA256)));
+    ck_assert_int_eq(isU8Eq(nullHash, hash, sizeof(cipher__SHA256)), 0);
 
     // If tx.In is changed, hash should change
     ptx2 = copyTransaction(handle1, &handle2);
@@ -547,7 +547,7 @@ START_TEST(TestTransactionHashInner)
     ck_assert(result == SKY_OK);
     result = SKY_coin_Transaction_HashInner(handle2, &hash2);
     ck_assert(result == SKY_OK);
-    ck_assert(!isU8Eq(hash1, hash2, sizeof(cipher__SHA256)));
+    ck_assert_int_eq(isU8Eq(hash1, hash2, sizeof(cipher__SHA256)), 0);
 
     // If tx.Out is changed, hash should change
     handle2 = 0;
@@ -567,7 +567,7 @@ START_TEST(TestTransactionHashInner)
     ck_assert(result == SKY_OK);
     result = SKY_coin_Transaction_HashInner(handle2, &hash2);
     ck_assert(result == SKY_OK);
-    ck_assert(!isU8Eq(hash1, hash2, sizeof(cipher__SHA256)));
+    ck_assert_int_eq(isU8Eq(hash1, hash2, sizeof(cipher__SHA256)), 0);
 
     // If tx.Head is changed, hash should not change
     ptx2 = copyTransaction(handle1, &handle2);

--- a/lib/cgo/tests/check_coin.transactions.c
+++ b/lib/cgo/tests/check_coin.transactions.c
@@ -1164,7 +1164,6 @@ Suite* coin_transaction_fork(void)
     tcase_add_checked_fixture(tc, setup, teardown);
 #if __linux__
     tcase_add_test_raise_signal(tc, TestTransactionPushInput, SKY_ABORT);
-    // tcase_add_test_raise_signal(tc, TestTransactionVerifyInput, SKY_ABORT);
     tcase_add_test_raise_signal(tc, TestTransactionSignInputs, SKY_ABORT);
 #elif __APPLE__
     tcase_add_exit_test(tc, TestTransactionPushInput, SKY_ABORT);

--- a/lib/cgo/tests/test_main.c
+++ b/lib/cgo/tests/test_main.c
@@ -9,6 +9,7 @@ int main(void)
     SRunner* sr_fork = srunner_create(coin_transaction_fork());
     srunner_add_suite(sr, cipher_bitcoin());
     srunner_add_suite(sr, cipher_crypto());
+    srunner_add_suite(sr, cipher_secp256k1());
     srunner_add_suite(sr, cipher_encrypt_scrypt_chacha20poly1305());
     srunner_add_suite(sr, cipher_hash());
     srunner_add_suite(sr, coin_blocks());

--- a/lib/cgo/tests/test_main.h
+++ b/lib/cgo/tests/test_main.h
@@ -15,6 +15,7 @@ Suite *cipher_bitcoin(void);
 Suite *cipher_address(void);
 Suite *cipher_testsuite(void);
 Suite *cipher_crypto(void);
+Suite *cipher_secp256k1(void);
 Suite *cipher_encrypt_scrypt_chacha20poly1305(void);
 Suite *cipher_hash(void);
 Suite *coin_blocks(void);


### PR DESCRIPTION
Fixes #79 

Changes:
- Added function `SKY_secp256k1_PubkeyFromSeckey`
- Added function `SKY_secp256k1_VerifyPubkey`
- Added function `SKY_secp256k1_VerifySecKey`
- Added function `SKY_secp256k1_ECDH`

Does this change need to mentioned in CHANGELOG.md?
yes

Requires testing
yes

Comments about testing , should you have some
