### PR TITLE
Fixed missing package in deploy 0.26.0

### DIFF
--- a/ci-scripts/docker_install_debian.sh
+++ b/ci-scripts/docker_install_debian.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
-apt-get update
-apt-get install gcc-6 g++-6 wget cmake libcurl3-gnutls -y
+set -ex
+
+apt update
+
+apt install gcc g++ wget make cmake libcurl3-gnutls -y --allow
 
 wget -c https://github.com/libcheck/check/releases/download/0.12.0/check-0.12.0.tar.gz
 tar -xzf check-0.12.0.tar.gz

--- a/ci-scripts/docker_install_debian.sh
+++ b/ci-scripts/docker_install_debian.sh
@@ -4,7 +4,7 @@ set -ex
 
 apt update
 
-apt install gcc g++ wget make cmake libcurl3-gnutls -y --allow
+apt install gcc g++ wget make cmake libcurl3-gnutls -y
 
 wget -c https://github.com/libcheck/check/releases/download/0.12.0/check-0.12.0.tar.gz
 tar -xzf check-0.12.0.tar.gz


### PR DESCRIPTION
Changes:
- Fixing the names of packages to install for the deploy image due to the update of the image to be used in Docker Hub

Does this change need to mentioned in CHANGELOG.md?
no

Requires testing
no

