### PR TITLE
Fixing release duplication in 0.26.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,10 +60,26 @@ jobs:
           docker_layer_caching: true
       - run: docker build  --build-arg QEMU_PLATFORM --build-arg QEMU_OS=debian --file $GOPATH/src/github.com/skycoin/libskycoin/docker/images/test-arm/Dockerfile  $GOPATH/src/github.com/skycoin/libskycoin -t skydev-test
 
-  publish-github-release_32:
+  deploy_arm_armv7:
     docker:
       - image: circleci/golang:1.12
     working_directory: $GOPATH/src/github.com/skycoin/libskycoin
+    environment:
+      QEMU_PLATFORM: armv7hf
+    steps:
+      - run: mkdir -p $GOPATH/src/github.com/ $GOPATH/src/github.com/skycoin
+      - checkout
+      - setup_remote_docker:
+          version: 18.06.0-ce
+          docker_layer_caching: true
+      - run: cd $GOPATH/src/github.com/skycoin/libskycoin/ci-scripts &&  bash deploy-arm.sh
+  
+  deploy_arm_armv8:
+    docker:
+      - image: circleci/golang:1.12
+    working_directory: $GOPATH/src/github.com/skycoin/libskycoin
+    environment:
+      QEMU_PLATFORM: aarch64
     steps:
       - run: mkdir -p $GOPATH/src/github.com/ $GOPATH/src/github.com/skycoin
       - checkout
@@ -80,4 +96,16 @@ workflows:
       - orangepi-plus2
       - raspberrypi2
       - bananapi_m1_plus
-      - publish-github-release_32
+      - hold: 
+          type: approval 
+          requires:
+           - raspberrypi3
+           - orangepi-plus2
+           - raspberrypi2
+           - bananapi_m1_plus
+      - deploy_arm_armv7:
+          requires:
+            - hold
+      - deploy_arm_armv8:
+          requires:
+            - hold

--- a/ci-scripts/deploy-arm.sh
+++ b/ci-scripts/deploy-arm.sh
@@ -6,7 +6,8 @@ git --version
 
 export VERSION="$(git describe --tags --exact-match HEAD)"
 
+echo $(QEMU_PLATFORM)
+
 if [[ "$VERSION" ]]; then
-	docker build  --build-arg SHA1=$CIRCLE_SHA1 --build-arg GITHUB_OAUTH_TOKEN --build-arg PROJECT_USERNAME=$CIRCLE_PROJECT_USERNAME --build-arg PROJECT_REPONAME=$CIRCLE_PROJECT_REPONAME --build-arg QEMU_PLATFORM=armv7hf --build-arg VERSION  --file $GOPATH/src/github.com/skycoin/libskycoin/docker/images/deploy-arm/Dockerfile  $GOPATH/src/github.com/skycoin/libskycoin -t skydev-deploy
-	docker build  --build-arg SHA1=$CIRCLE_SHA1 --build-arg GITHUB_OAUTH_TOKEN --build-arg PROJECT_USERNAME=$CIRCLE_PROJECT_USERNAME --build-arg PROJECT_REPONAME=$CIRCLE_PROJECT_REPONAME --build-arg QEMU_PLATFORM=aarch64 --build-arg VERSION  --file $GOPATH/src/github.com/skycoin/libskycoin/docker/images/deploy-arm/Dockerfile  $GOPATH/src/github.com/skycoin/libskycoin -t skydev-deploy
+	docker build  --build-arg SHA1=$CIRCLE_SHA1 --build-arg GITHUB_OAUTH_TOKEN --build-arg PROJECT_USERNAME=$CIRCLE_PROJECT_USERNAME --build-arg PROJECT_REPONAME=$CIRCLE_PROJECT_REPONAME --build-arg QEMU_PLATFORM --build-arg VERSION  --file $GOPATH/src/github.com/skycoin/libskycoin/docker/images/deploy-arm/Dockerfile  $GOPATH/src/github.com/skycoin/libskycoin -t skydev-deploy
 fi

--- a/ci-scripts/deploy-arm.sh
+++ b/ci-scripts/deploy-arm.sh
@@ -6,7 +6,7 @@ git --version
 
 export VERSION="$(git describe --tags --exact-match HEAD)"
 
-echo $(QEMU_PLATFORM)
+echo $QEMU_PLATFORM
 
 if [[ "$VERSION" ]]; then
 	docker build  --build-arg SHA1=$CIRCLE_SHA1 --build-arg GITHUB_OAUTH_TOKEN --build-arg PROJECT_USERNAME=$CIRCLE_PROJECT_USERNAME --build-arg PROJECT_REPONAME=$CIRCLE_PROJECT_REPONAME --build-arg QEMU_PLATFORM --build-arg VERSION  --file $GOPATH/src/github.com/skycoin/libskycoin/docker/images/deploy-arm/Dockerfile  $GOPATH/src/github.com/skycoin/libskycoin -t skydev-deploy

--- a/docker/images/deploy-arm/Dockerfile
+++ b/docker/images/deploy-arm/Dockerfile
@@ -21,6 +21,6 @@ ENV OS="Linux"
 RUN make -C $GOPATH/src/github.com/skycoin/libskycoin build
 RUN tar -czf libskycoin-${VERSION}-${OS}-${ARCH}.tar.gz -C $GOPATH/src/github.com/skycoin/libskycoin/build $GOPATH/src/github.com/skycoin/libskycoin/build/*
 RUN go get github.com/tcnksm/ghr
-RUN ghr -t ${GITHUB_OAUTH_TOKEN} -u ${PROJECT_USERNAME} -r ${PROJECT_REPONAME} -c ${SHA1} -replace -draft ${VERSION} libskycoin-${VERSION}-${OS}-${ARCH}.tar.gz
+RUN ghr -t ${GITHUB_OAUTH_TOKEN} -u ${PROJECT_USERNAME} -r ${PROJECT_REPONAME} -c ${SHA1} -replace -draft -n "libskycoin ${VERSION}" ${VERSION} libskycoin-${VERSION}-${OS}-${ARCH}.tar.gz
 
 RUN [ "cross-build-end" ]


### PR DESCRIPTION
Changes:
- Adding another job since the two compilations give a log size error and adding to the release files the release title
